### PR TITLE
add configurable nix command & home-manager support

### DIFF
--- a/command-not-found.sh
+++ b/command-not-found.sh
@@ -81,7 +81,7 @@ The program '$cmd' is currently not installed.
 EOF
 
                 if [ $home_manager ]; then
-                   echo "You can install it by adding one of the following to your Home Manager configuration:"
+                   echo "You can install it by adding the following to your Home Manager configuration:"
                    >&2 echo "  home.packages = [ pkgs.${attrs%.*} ];"
                 else
                    echo "You can install it by typing:"

--- a/command-not-found.sh
+++ b/command-not-found.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-home_manager=${USE_NIX_COMMAND:=false}
+home_manager=${USE_HOME_MANAGER:=false}
 nix_command=${USE_NIX_COMMAND:=false}
 
 # for bash 4

--- a/command-not-found.sh
+++ b/command-not-found.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+home_manager=${USE_NIX_COMMAND:=false}
+nix_command=${USE_NIX_COMMAND:=false}
+
 # for bash 4
 # this will be called when a command is entered
 # but not found in the user’s path + environment
@@ -43,7 +46,7 @@ command_not_found_handle () {
 The program '$cmd' is currently not installed. It is provided by
 the package '$toplevel.$attrs', which I will now install for you.
 EOF
-                if [ -e "$HOME/.nix-profile/manifest.json" ]; then
+                if [ -e "$HOME/.nix-profile/manifest.json" ] || [ $nix_command ]; then
                     nix profile install $toplevel#$attrs
                 else
                     nix-env -iA $toplevel.$attrs
@@ -71,14 +74,24 @@ $cmd: command not found
 EOF
                 fi
             else
-                if [ -e "$HOME/.nix-profile/manifest.json" ]; then
+                if [ -e "$HOME/.nix-profile/manifest.json" ] || [ $nix_command ]; then
                     >&2 cat <<EOF
-The program '$cmd' is currently not installed. You can install it
-by typing:
-  nix profile install $toplevel#$attrs
+The program '$cmd' is currently not installed.
+
+EOF
+
+                if [ $home_manager ]; then
+                   echo "You can install it by adding one of the following to your Home Manager configuration:"
+                   >&2 echo "  home.packages = [ pkgs.${attrs%.*} ];"
+                else
+                   echo "You can install it by typing:"
+                   >&2 echo "  nix profile install $toplevel#$attrs"
+                fi
+
+                    >&2 cat <<EOF
 
 Or run it once with:
-  nix shell $toplevel#$attrs -c $cmd ...
+  nix run $toplevel#$attrs
 EOF
                 else
                     >&2 cat <<EOF
@@ -94,15 +107,24 @@ EOF
             ;;
         *)
             >&2 cat <<EOF
-The program '$cmd' is currently not installed. It is provided by
-several packages. You can install it by typing one of the following:
+The program '$cmd' is currently not installed. It is provided by several packages.
+
 EOF
+
+            if [ $home_manager ]; then
+               echo "You can install it by adding one of the following to your Home Manager configuration:"
+            fi
 
             # ensure we get each element of attrs
             # in a cross platform way
             while read attr; do
-                if [ -e "$HOME/.nix-profile/manifest.json" ]; then
-                    >&2 echo "  nix profile install $toplevel#$attr"
+                if [ -e "$HOME/.nix-profile/manifest.json" ] || [ $nix_command ]; then
+                    if [ $home_manager ]; then
+                       >&2 echo "  home.packages = [ pkgs.${attr%.*} ];"
+                    else
+                       echo "You can install it by typing one of the following:"
+                       >&2 echo "  nix profile install $toplevel#$attr"
+                    fi
                 else
                     >&2 echo "  nix-env -iA $toplevel.$attr"
                 fi
@@ -114,8 +136,8 @@ Or run it once with:
 EOF
 
             while read attr; do
-                if [ -e "$HOME/.nix-profile/manifest.json" ]; then
-                    >&2 echo "  nix shell $toplevel#$attr -c $cmd ..."
+                if [ -e "$HOME/.nix-profile/manifest.json" ] || [ $nix_command ]; then
+                    >&2 echo "  nix run $toplevel#$attr"
                 else
                     >&2 echo "  nix-shell -p $attr --run '$cmd ...'"
                 fi

--- a/modules/hm.nix
+++ b/modules/hm.nix
@@ -1,0 +1,83 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.programs.nix-index-fork;
+  useHomeManager = "export USE_HOME_MANAGER=true";
+  useNixCommand =
+    lib.optionalString cfg.enableNixCommand "export USE_NIX_COMMAND=true";
+in
+{
+  meta.maintainers = with lib.hm.maintainers; [ ambroisie gvolpe ];
+
+  options.programs.nix-index-fork = with lib; {
+    enable = mkEnableOption "nix-index, a file database for nixpkgs";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.nix-index;
+      defaultText = literalExpression "pkgs.nix-index";
+      description = "Package providing the {command}`nix-index` tool.";
+    };
+
+    enableBashIntegration = mkEnableOption "Bash integration" // {
+      default = false;
+    };
+
+    enableZshIntegration = mkEnableOption "Zsh integration" // {
+      default = false;
+    };
+
+    enableFishIntegration = mkEnableOption "Fish integration" // {
+      default = false;
+    };
+
+    enableNixCommand = mkEnableOption "Enable Nix command suggestions (flakes)" // {
+      default = false;
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions =
+      let
+        checkOpt = name: {
+          assertion = cfg.${name} -> !config.programs.command-not-found.enable;
+          message = ''
+            The 'programs.command-not-found.enable' option is mutually exclusive
+            with the 'programs.nix-index.${name}' option.
+          '';
+        };
+      in
+      [ (checkOpt "enableBashIntegration") (checkOpt "enableZshIntegration") ];
+
+    home.packages = [ cfg.package ];
+
+    programs.bash.initExtra = lib.mkIf cfg.enableBashIntegration ''
+      ${useHomeManager}
+      ${useNixCommand}
+      source ${cfg.package}/etc/profile.d/command-not-found.sh
+    '';
+
+    programs.zsh.initExtra = lib.mkIf cfg.enableZshIntegration ''
+      ${useHomeManager}
+      ${useNixCommand}
+      source ${cfg.package}/etc/profile.d/command-not-found.sh
+    '';
+
+    # See https://github.com/bennofs/nix-index/issues/126
+    programs.fish.interactiveShellInit =
+      let
+        wrapper = pkgs.writeScript "command-not-found" ''
+          #!${pkgs.bash}/bin/bash
+          ${useHomeManager}
+          ${useNixCommand}
+          source ${cfg.package}/etc/profile.d/command-not-found.sh
+          command_not_found_handle "$@"
+        '';
+      in
+      lib.mkIf cfg.enableFishIntegration ''
+        function __fish_command_not_found_handler --on-event fish_command_not_found
+            ${wrapper} $argv
+        end
+      '';
+  };
+}


### PR DESCRIPTION
## How to use

Add the following input to your `flake.nix` file:

```nix
{ 
  nix-index = {
    url = github:gvolpe/nix-index;
    inputs.nixpkgs.follows = "nixpkgs"; #optional
  };
}
```

Import the Home Manager module:

```nix
{
  homeConfigurations."username" = home-manager.lib.homeManagerConfiguration {
    inherit pkgs;
    modules = [ inputs.nix-index.homeManagerModules.${system}.default ];
  };
}
```

Enable the `nix-index-fork` program with your preferred options:

```nix
{
  programs = {
    nix-index-fork = {
      enable = true;
      enableFishIntegration = true;
      enableNixCommand = true;
    };

    command-not-found.enable = false;
  };
}
```

### Enjoy!

![satty-20241220-13:17:44](https://github.com/user-attachments/assets/94e10fac-0c9f-4881-9cc5-1389cc5ea36f)